### PR TITLE
test: add analyze-doe error path test

### DIFF
--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -504,3 +504,27 @@ def test_validate_model_policy_requires_local_ollama_model_available(monkeypatch
     monkeypatch.setattr(cli_module.subprocess, "run", fake_run)
     cli_module._validate_model_policy(provider="ollama", model="qwen3.5:0.8b", allow_debug_model=False)
     assert captured["cmd"] == "ollama list"
+
+
+def test_cli_analyze_doe_exits_on_analysis_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that analyze-doe exits with code 1 when analysis returns None."""
+    input_csv = tmp_path / "input.csv"
+    input_csv.write_text("a,b,score\n1,1,10\n2,2,20\n", encoding="utf-8")
+
+    def fake_analyze(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(cli_module, "analyze_factorial_anova", fake_analyze)
+
+    result = runner.invoke(
+        app,
+        [
+            "analyze-doe",
+            "--input-csv",
+            str(input_csv),
+            "--output-csv",
+            str(tmp_path / "output.csv"),
+        ],
+    )
+
+    assert result.exit_code == 1


### PR DESCRIPTION
Tests the CLI exit code 1 when analyze_factorial_anova returns None.

## Summary
- What changed and why.

## Traceability
- Paper section(s):
- Traceability IDs from `docs/TRACEABILITY_MATRIX.md`:

## Behavioral Impact
- [ ] No behavior change
- [ ] Behavior intentionally changed (describe below)

## Reproducibility Impact
- [ ] No reproducibility impact
- [ ] Reproducibility artifacts/schema updated (describe below)

## Validation
- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] `uv run mypy src tests`
- [ ] `uv build`

## Documentation
- [ ] README updated
- [ ] Architecture docs updated
- [ ] Hyperparameter/runtime docs updated

## Legacy Surface Scan
- [ ] Confirmed no active notebook/legacy compatibility dependency introduced
- [ ] Ran `uv run pytest tests/unit/repo/test_legacy_surface_scan.py`

## Notes for Reviewer
- Risks:
- Rollback plan:
